### PR TITLE
Fixing JSON parse error being thrown, returning friendlier error message

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -65,9 +65,13 @@
         url: url
       }, function(error, request, body) {
         var err;
-        body = JSON.parse(body);
-        if (body.meta.status !== 200) {
-          err = body.meta.msg;
+        try {
+          body = JSON.parse(body);
+          if (body.meta.status !== 200) {
+            err = body.meta.msg;
+          }
+        } catch(e) {
+          err = "Invalid Response";
         }
         return fn.call(body, err, body.response);
       });


### PR DESCRIPTION
A non-JSON response would throw an ugly JSON parse error and stack trace would point inside of the module. (encountered this when getting a 404 from tumblr.)

Added try/catch around the json parsing of the response, and returning "Invalid Response" as the error when non-json response is encountered.
